### PR TITLE
Hover component

### DIFF
--- a/apps/controller-aragon-fundraising/app/src/components/Chart/index.js
+++ b/apps/controller-aragon-fundraising/app/src/components/Chart/index.js
@@ -1,5 +1,5 @@
 import { DropDown } from '@aragon/ui'
-import { differenceInDays, format, startOfMinute, startOfMonth, startOfWeek, subDays, subHours, subSeconds } from 'date-fns'
+import { differenceInDays, format, startOfMinute, startOfMonth, startOfWeek, subDays, subHours, subSeconds, startOfDay, endOfDay } from 'date-fns'
 import React, { useState } from 'react'
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ReferenceDot, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import styled from 'styled-components'
@@ -207,8 +207,8 @@ export default () => {
   const [activeItem, setActiveItem] = useState(0)
   const [activeNavItem, setActiveNavItem] = useState(0)
   const [date, setDate] = useState({
-    start: new Date(new Date().getTime() - 1000000000),
-    end: new Date(),
+    start: startOfDay(new Date()),
+    end: endOfDay(new Date()),
   })
 
   return (
@@ -319,10 +319,10 @@ const Chart = styled.div`
       }
       .item:hover {
         cursor: pointer;
-        border-bottom: 2px solid #1dd9d5;
+        border-bottom: 2px solid #08bee5;
       }
       .item.active {
-        border-bottom: 2px solid #1dd9d5;
+        border-bottom: 2px solid #08bee5;
       }
 
       .item > span:nth-child(1) {

--- a/apps/controller-aragon-fundraising/app/src/components/DateRange/DatePicker.js
+++ b/apps/controller-aragon-fundraising/app/src/components/DateRange/DatePicker.js
@@ -112,6 +112,16 @@ class DatePicker extends React.PureComponent {
             </DayView>
           ))}
         </MonthView>
+        {this.props.onApply && (
+          <div className="buttons">
+            <button className="clear-button" onClick={this.props.onClear}>
+              Clear
+            </button>
+            <button className="apply-button" onClick={this.props.onApply}>
+              Apply
+            </button>
+          </div>
+        )}
       </Container>
     )
   }
@@ -157,6 +167,32 @@ const Container = styled.div`
   border: 1px solid ${theme.contentBorder};
   border-radius: 3px;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+    padding: 1rem 2rem;
+  }
+
+  .buttons button {
+    border-radius: 3px;
+    padding: 0.25rem 2rem;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .clear-button {
+    border: 1px solid rgba(209, 209, 209, 0.75);
+    background: white;
+  }
+
+  .apply-button {
+    background: linear-gradient(166.65deg, #00c7e4 6.62%, #00efe2 122.8%, #00efe2 122.8%);
+    border: none;
+    color: white;
+  }
 
   ${props =>
     props.overlay &&
@@ -211,7 +247,7 @@ const DayView = styled.li`
   ${props =>
     props.today &&
     css`
-      border: 1px solid ${mainColor};
+      border: 1px solid #01c8e4;
     `}
 
   ${props =>
@@ -225,8 +261,8 @@ const DayView = styled.li`
     props.selected &&
     css`
       &&& {
-        background: ${mainColor};
-        border-color: ${mainColor};
+        background: #01c8e4;
+        border-color: #01c8e4;
         color: ${theme.negativeText};
       }
     `}

--- a/apps/controller-aragon-fundraising/app/src/components/DateRange/DateRangeInput.js
+++ b/apps/controller-aragon-fundraising/app/src/components/DateRange/DateRangeInput.js
@@ -54,16 +54,26 @@ class DateRangeInput extends React.PureComponent {
 
   handleClickOutside = event => {
     if (this.rootRef && !this.rootRef.contains(event.target)) {
-      this.setState({ showPicker: false }, () => {
-        const { startDate, endDate } = this.state
-        if (startDate && endDate) {
-          this.props.onChange({
-            start: startOfDay(startDate),
-            end: endOfDay(endDate),
-          })
-        }
+      this.setState({ showPicker: false })
+    }
+  }
+
+  handleApply = () => {
+    const { startDate, endDate } = this.state
+    if (startDate && endDate) {
+      this.props.onChange({
+        start: startOfDay(startDate),
+        end: endOfDay(endDate),
       })
     }
+  }
+
+  handleClear = () => {
+    this.setState({ startDate: new Date(), endDate: new Date() })
+    this.props.onChange({
+      start: startOfDay(new Date()),
+      end: endOfDay(new Date()),
+    })
   }
 
   handleSelectStartDate = date => {
@@ -88,10 +98,7 @@ class DateRangeInput extends React.PureComponent {
 
     const icon = showPicker || active ? <IconCalendarSelected /> : <IconCalendar />
     const value = this.formattedStartDate && this.formattedEndDate ? `${this.formattedStartDate} - ${this.formattedEndDate}` : ''
-    const placeholder = `${this.formattedStartDate ? this.formattedStartDate : DATE_PLACEHOLDER} - ${
-      this.formattedEndDate ? this.formattedEndDate : this.formattedStartDate ? DATE_PLACEHOLDER : formatDate(new Date(), this.props.format)
-    }`
-
+    const placeholder = `Start date - End date`
     return (
       <StyledContainer
         ref={el => (this.rootRef = el)}
@@ -110,7 +117,15 @@ class DateRangeInput extends React.PureComponent {
               onSelect={this.handleSelectStartDate}
               overlay={false}
             />
-            <DatePicker key={`end-picker-${endDate}`} name="end-date-picker" currentDate={endDate} onSelect={this.handleSelectEndDate} overlay={false} />
+            <DatePicker
+              key={`end-picker-${endDate}`}
+              name="end-date-picker"
+              currentDate={endDate}
+              onSelect={this.handleSelectEndDate}
+              onApply={this.handleApply}
+              onClear={this.handleClear}
+              overlay={false}
+            />
           </StyledDatePickersContainer>
         )}
       </StyledContainer>
@@ -137,6 +152,9 @@ const StyledContainer = styled.div`
 const StyledTextInput = styled(TextInput)`
   width: 28ch;
   ${font({ monospace: true })};
+  &:hover {
+    cursor: pointer;
+  }
 `
 
 const StyledDatePickersContainer = styled.div`
@@ -145,6 +163,7 @@ const StyledDatePickersContainer = styled.div`
   border: 1px solid ${theme.contentBorder};
   border-radius: 3px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  background: white;
 
   > div {
     border: 0;
@@ -152,7 +171,7 @@ const StyledDatePickersContainer = styled.div`
   }
 
   ${breakpoint(
-    'medium',
+    'large',
     `
       display: flex;
       flex-direction: row;

--- a/apps/controller-aragon-fundraising/app/src/components/DateRange/TextInput.js
+++ b/apps/controller-aragon-fundraising/app/src/components/DateRange/TextInput.js
@@ -14,6 +14,9 @@ const baseStyles = css`
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   color: ${theme.textPrimary};
   appearance: none;
+  &:hover {
+    cursor: pointer;
+  }
   &:focus {
     outline: none;
     border-color: ${theme.contentBorderActive};
@@ -31,15 +34,7 @@ const TextInput = styled.input`
 
 TextInput.propTypes = {
   required: PropTypes.bool,
-  type: PropTypes.oneOf([
-    'email',
-    'number',
-    'password',
-    'search',
-    'tel',
-    'text',
-    'url',
-  ]),
+  type: PropTypes.oneOf(['email', 'number', 'password', 'search', 'tel', 'text', 'url']),
 }
 
 TextInput.defaultProps = {
@@ -49,18 +44,7 @@ TextInput.defaultProps = {
 
 // Text input wrapped to allow adornments
 const WrapperTextInput = React.forwardRef(
-  (
-    {
-      adornment,
-      adornmentPosition,
-      adornmentSettings: {
-        width: adornmentWidth = 34,
-        padding: adornmentPadding = 4,
-      },
-      ...props
-    },
-    ref
-  ) => {
+  ({ adornment, adornmentPosition, adornmentSettings: { width: adornmentWidth = 34, padding: adornmentPadding = 4 }, ...props }, ref) => {
     if (!adornment) {
       return <TextInput ref={ref} {...props} />
     }
@@ -75,9 +59,7 @@ const WrapperTextInput = React.forwardRef(
         <TextInput
           ref={ref}
           css={`
-            ${adornmentPosition === 'end'
-              ? 'padding-right'
-              : 'padding-left'}: ${adornmentWidth - adornmentPadding * 2}px;
+            ${adornmentPosition === 'end' ? 'padding-right' : 'padding-left'}: ${adornmentWidth - adornmentPadding * 2}px;
           `}
           {...props}
         />
@@ -87,13 +69,14 @@ const WrapperTextInput = React.forwardRef(
             top: 0;
             bottom: 0;
             height: 100%;
-            ${adornmentPosition === 'end'
-              ? 'right'
-              : 'left'}: ${adornmentPadding}px;
+            ${adornmentPosition === 'end' ? 'right' : 'left'}: ${adornmentPadding}px;
             display: flex;
             align-items: center;
             justify-content: center;
             color: ${theme.textSecondary};
+            &:hover {
+              cursor: pointer;
+            }
           `}
         >
           {adornment}

--- a/apps/controller-aragon-fundraising/app/src/components/HoverNotification/HoverNotification.js
+++ b/apps/controller-aragon-fundraising/app/src/components/HoverNotification/HoverNotification.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
+import { font } from '../../utils/styles'
+import { theme } from '@aragon/ui'
+
+// TODO: standarize the z-index across all components
+const baseStyles = css`
+  position: absolute;
+  z-index: 5;
+  border-radius: 4px;
+  background: ${theme.badgeAppBackground};
+  border-left: 2px solid ${theme.badgeAppForeground};
+  margin: -0.25rem 2rem;
+  padding: 1rem;
+  span {
+    ${font({ size: 'small', weight: 'normal' })}
+    color: ${theme.badgeAppForeground};
+  }
+`
+
+const HoverNotification = styled.div`
+  ${baseStyles}
+`
+
+HoverNotification.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  copy: PropTypes.string,
+}
+
+HoverNotification.defaultProps = {
+  copy: '',
+}
+
+const WrapperHoverNotification = ({ children, copy, hoverSettings: { width: hoverWidth = 350, height: hoverHeight = 150 } }) => {
+  const [isHovering, setIsHovering] = useState(false)
+  return (
+    <div onMouseEnter={() => setIsHovering(true)} onMouseLeave={() => setIsHovering(false)} style={{ display: 'inline-flex' }}>
+      {children}
+      {isHovering && (
+        <HoverNotification
+          css={`
+            width: ${hoverWidth}px;
+            height: ${hoverHeight}px;
+          `}
+        >
+          <span>{copy}</span>
+        </HoverNotification>
+      )}
+    </div>
+  )
+}
+
+WrapperHoverNotification.propTypes = {
+  ...HoverNotification.propTypes,
+  children: PropTypes.node.isRequired,
+  hoverSettings: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
+}
+
+WrapperHoverNotification.defaultProps = {
+  ...HoverNotification.defaultProps,
+  children: null,
+  hoverSettings: {},
+}
+
+export default WrapperHoverNotification

--- a/apps/controller-aragon-fundraising/app/src/components/NewOrderSidePanel.js
+++ b/apps/controller-aragon-fundraising/app/src/components/NewOrderSidePanel.js
@@ -1,7 +1,9 @@
-import { Button, DropDown, Field, Info, SidePanel, TabBar, Table, TableCell, TableRow, Text, TextInput, theme } from '@aragon/ui'
+import { DropDown, SidePanel, Text, TextInput } from '@aragon/ui'
 import React from 'react'
 import styled from 'styled-components'
 import transferArrows from '../assets/transferArrows.svg'
+import TabBar from './TabBar/TabBar'
+import Button from './Button/Button'
 
 const collateralTokens = ['DAI', 'ANT']
 
@@ -89,23 +91,43 @@ export default class NewOrderSidePanel extends React.Component {
       const orderType = activeTab === 0
       return (
         <div>
-          <FlexWrapper>
+          <div>
             <Text weight="bold">TOTAL</Text>
-            <Text weight="bold">0</Text>
-            <Text weight="bold">{orderType ? 'ATL' : 'USD'}</Text>
-          </FlexWrapper>
-          <FlexWrapper>
+            <div css="float: right;">
+              <Text weight="bold" css={orderType ? 'margin-right: 1.5rem;' : 'margin-right: 21px;'}>
+                0
+              </Text>
+              <Text weight="bold">{orderType ? 'ATL' : 'USD'}</Text>
+            </div>
+          </div>
+          <div css="margin-bottom: 2rem;">
             <Text weight="bold" />
-            <Text color="grey">0</Text>
-            <Text color="grey">{orderType ? 'USD' : 'ATL'}</Text>
-          </FlexWrapper>
-          <Button mode="strong" type="submit" wide onClick={onSubmit}>
+            <div css="float: right;">
+              <Text color="grey" css={orderType ? 'margin-right: 21px;' : 'margin-right: 1.5rem;'}>
+                0
+              </Text>
+              <Text color="grey">{orderType ? 'USD' : 'ATL'}</Text>
+            </div>
+          </div>
+          <Button mode="strong" type="submit" css="width: 100%;" onClick={onSubmit}>
             {orderType ? 'Place buy order' : 'Place sell order'}
           </Button>
-          <Info.Action style={{ marginTop: '20px' }} title={orderType ? 'Buy order' : 'Sell order'}>
-            As more collateral is staked into the bonding curve, you may opt to sell a small share of your tokens in order to redeem your collateral from the
-            contract where a percentage fee goes to the development of the project.
-          </Info.Action>
+          <div
+            css={`
+              background-color: #f1fbff;
+              border-radius: 4px;
+              color: #188aaf;
+              padding: 1rem;
+              margin-top: 2rem;
+              border-left: 2px solid #0ab0e5;
+            `}
+          >
+            <p css="font-weight: 700;">Info</p>
+            <p>
+              For a {orderType ? 'buying' : 'selling'} order, the more collateral is staked into the bonding curve, you may opt to sell a small share of your
+              tokens in order to redeem collateral from the contract and fund the development of the project.
+            </p>
+          </div>
         </div>
       )
     }
@@ -116,64 +138,95 @@ export default class NewOrderSidePanel extends React.Component {
           <TabBar items={['Buy', 'Sell']} selected={activeTab} onChange={idx => this.setState({ activeTab: idx })} />
         </TabBarWrapper>
         <Form onSubmit={this.handleSubmit}>
-          <Table noSideBorders={true}>
-            <TableRow>
-              <TableCell
-                style={styles.noBorderCell}
+          <div
+            css={`
+              display: flex;
+              justify-content: space-between;
+              align-items: center;
+              margin-bottom: 3rem;
+            `}
+          >
+            <div css="width: 50%;">
+              <p
                 css={`
-                  justify-content: flex-start;
-                  white-space: nowrap;
+                  text-transform: uppercase;
+                  color: #637381;
+                  font-size: 14px;
+                  opacity: 0.7;
                 `}
               >
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                  }}
+                Order amount
+              </p>
+              <div
+                css={`
+                  display: flex;
+                  align-items: center;
+                `}
+              >
+                <StyledTextInput
+                  adornment={<a style={styles.maxBalanceLink}>MAX</a>}
+                  type="number"
+                  style={styles.selectionInputLeft}
+                  ref={amount => (this.amountInput = amount)}
+                  value={amount}
+                  onChange={this.handleAmountChange}
+                  wide
+                  required
+                />
+                <StyledDropdown>
+                  <DropDown items={collateralTokens} active={activeItem} onChange={this.handleTokenChange} />
+                </StyledDropdown>
+              </div>
+            </div>
+
+            <img
+              src={transferArrows}
+              css={`
+                height: 16px;
+                margin: 0 0.5rem;
+                margin-top: 1rem;
+              `}
+            />
+
+            <div
+              css={`
+                display: flex;
+                align-items: center;
+                white-space: nowrap;
+              `}
+            >
+              <div
+                css={`
+                  > div {
+                    width: 100%;
+                  }
+                `}
+              >
+                <p
+                  css={`
+                    text-transform: uppercase;
+                    color: #637381;
+                    font-size: 14px;
+                    opacity: 0.7;
+                  `}
                 >
-                  <Field css={fieldCss} label="Order Amount">
-                    <TextInput
-                      adornment={<a style={styles.maxBalanceLink}>MAX</a>}
-                      type="number"
-                      style={styles.selectionInputLeft}
-                      ref={amount => (this.amountInput = amount)}
-                      value={amount}
-                      onChange={this.handleAmountChange}
-                      wide
-                      required
-                    />
-                  </Field>
-                  <StyledDropdown>
-                    <DropDown items={collateralTokens} active={activeItem} onChange={this.handleTokenChange} />
-                  </StyledDropdown>
-                </div>
-              </TableCell>
-              <TableCell
-                style={styles.noBorderCell}
-                css={`
-                  justify-content: flex-start;
-                  white-space: nowrap;
-                `}
-              >
-                <img src={transferArrows} style={{ height: '16px', margin: '0 0.5rem' }} />
-                <Field css={fieldCss} label="Token Amount">
-                  <TextInput
-                    style={styles.selectionInputRight}
-                    adornment={<span style={{ paddingRight: '14px' }}>ATL</span>}
-                    adornmentPosition={'end'}
-                    ref={amount => (this.amountInput = amount)}
-                    value={amount}
-                    onChange={this.handleAmountChange}
-                    required
-                    wide
-                  />
-                </Field>
-              </TableCell>
-            </TableRow>
-            <Text color={'rgb(150, 150, 150)'} size="small" style={styles.daiPrice}>
-              ${daiRate} USD
-            </Text>
-          </Table>
+                  Token amount
+                </p>
+                <StyledTextInput
+                  type="number"
+                  style={styles.selectionInputRight}
+                  adornment={<span style={{ paddingRight: '14px' }}>ATL</span>}
+                  adornmentPosition={'end'}
+                  ref={amount => (this.amountInput = amount)}
+                  value={amount}
+                  onChange={this.handleAmountChange}
+                  required
+                  wide
+                />
+              </div>
+            </div>
+          </div>
+
           {renderOrderType(activeTab, onSubmit)}
         </Form>
       </SidePanel>
@@ -181,28 +234,22 @@ export default class NewOrderSidePanel extends React.Component {
   }
 }
 
-const FlexWrapper = styled.div`
-  display: flex;
-  margin-bottom: 10px;
-
-  span:first-child {
-    flex: 0 1 326px;
-  }
-
-  span:last-child {
-    margin-left: 1.5rem;
-  }
+const StyledTextInput = styled(TextInput)`
+  border: 1px solid #dde4e9;
+  box-shadow: none;
+  width: 100%;
 `
 const StyledDropdown = styled.div`
-  height: 40px;
   > div {
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+    box-shadow: none;
   }
-  > div > div {
+
+  > div > div:first-child {
     padding-right: 26px;
     border-radius: 0 3px 3px 0;
-    border-left: 0px;
-    margin-top: 1px;
+    border: 1px solid #dde4e9;
+    border-left: none;
+    height: 40px;
   }
 `
 const Form = styled.form`
@@ -211,10 +258,4 @@ const Form = styled.form`
 
 const TabBarWrapper = styled.div`
   margin: 0 -30px 30px;
-`
-
-const fieldCss = `
-  > label > div {
-    width: auto;
-  }
 `

--- a/apps/controller-aragon-fundraising/app/src/screens/Overview.js
+++ b/apps/controller-aragon-fundraising/app/src/screens/Overview.js
@@ -1,9 +1,6 @@
-import { Text } from '@aragon/ui'
 import BN from 'bignumber.js'
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import antImage from '../assets/ant.png'
-import daiImage from '../assets/dai.png'
 import Chart from '../components/Chart'
 import Box from '../components/Box/Box'
 
@@ -39,37 +36,45 @@ export default () => {
       <KeyMetrics heading="Key metrics" padding={false}>
         <ul>
           <li>
-            <p className="title">Price</p>
-            <p className="number">$106,03.36</p>
+            <div>
+              <p className="title">Price</p>
+              <p className="number">$106,03.36</p>
+            </div>
             <p className="sub-number green">+$4.82 (0.5%)</p>
           </li>
           <li>
-            <div className="title">
-              <p>Market Cap</p>
+            <div>
+              <p className="title">Market Cap</p>
+              <p className="number">$675,02 M</p>
             </div>
-            <p className="number">$675,02 M</p>
             <p className="sub-number green">+$4.82M</p>
           </li>
           <li>
-            <div className="title">
-              <p>Trading Volume</p>
+            <div>
+              <p className="title">Trading Volume</p>
+              <p className="number">$1.5 M</p>
             </div>
-            <p className="number">$1.5 M</p>
             <p className="sub-number green">$48M (Y)</p>
           </li>
           <li>
-            <p className="title">Token Supply</p>
-            <p className="number">100,013 M</p>
+            <div>
+              <p className="title">Token Supply</p>
+              <p className="number">100,013 M</p>
+            </div>
             <p className="sub-number red">-$23.82 (0.5%)</p>
           </li>
           <li>
-            <p className="title">Reserves</p>
-            <p className="number">$25,07 M</p>
+            <div>
+              <p className="title">Reserves</p>
+              <p className="number">$25,07 M</p>
+            </div>
             <p className="sub-number red">-$0.82M</p>
           </li>
           <li>
-            <p className="title">Monthly Allowance</p>
-            <p className="number">$150.5 K</p>
+            <div>
+              <p className="title">Monthly Allowance</p>
+              <p className="number">$150.5 K</p>
+            </div>
             <p className="sub-number green">$48M (Y)</p>
           </li>
         </ul>
@@ -151,8 +156,15 @@ const KeyMetrics = styled(Box)`
     }
 
     li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
       padding: 1rem;
       border-bottom: 1px solid #dde4e9;
+
+      .number {
+        margin-bottom: 0;
+      }
     }
 
     li:last-child {

--- a/apps/controller-aragon-fundraising/app/src/screens/Reserves.js
+++ b/apps/controller-aragon-fundraising/app/src/screens/Reserves.js
@@ -1,9 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react'
-import { Badge, Button, Card, Form, Field, Table, TableRow, TableCell, Text, theme } from '@aragon/ui'
+import React, { useRef, useState } from 'react'
+import { Badge, Button, Text } from '@aragon/ui'
 import styled from 'styled-components'
+import HoverNotification from '../components/HoverNotification/HoverNotification'
 import Box from '../components/Box/Box'
 import TextInput from '../components/Input/TextInput'
 import EditIcon from '../assets/EditIcon.svg'
+
+// In this copy we should display the user the percentage of max increase of the tap
+const hoverTextNotifications = [
+  'This will update the monthly allocation (tap rate) i.e. how much funds can be released within the bonding curve contract per 30-day period. Note: this value must be less than the max increase limit set inside the contract.',
+  "You're essentially bonding collateral when buying tokens (increasing the supply), and burning collateral when selling tokens (decreasing the supply). These relationships are defined by the smart contract.",
+]
 
 export default () => {
   const [state, setState] = useState({
@@ -32,7 +39,7 @@ export default () => {
         <div className="settings-content">
           <div css="margin-right: 4rem;">
             <div css="display: flex; flex-direction: column; margin-bottom: 1rem;">
-              {NotificationLabel('Monthly allocation')}
+              {NotificationLabel('Monthly allocation', hoverTextNotifications[0])}
               <StyledTextInput
                 ref={inputRef}
                 adornment={
@@ -60,11 +67,11 @@ export default () => {
           </div>
           <div>
             <div css="display: flex; flex-direction: column; margin-bottom: 1.5rem;">
-              {NotificationLabel('ANT collateralization ratio')}
+              {NotificationLabel('ANT collateralization ratio', hoverTextNotifications[1])}
               <Text>{antRatio}%</Text>
             </div>
             <div css="display: flex; flex-direction: column;">
-              {NotificationLabel('DAI collateralization ratio')}
+              {NotificationLabel('DAI collateralization ratio', hoverTextNotifications[1])}
               <Text>{daiRatio}%</Text>
             </div>
           </div>
@@ -90,12 +97,14 @@ export default () => {
   )
 }
 
-const NotificationLabel = label => (
+const NotificationLabel = (label, hoverText) => (
   <Text css="margin-bottom: 0.5rem;">
     {label}
-    <Badge.Notification style={{ margin: '0 10px', cursor: 'pointer', background: '#7C80F2', boxShadow: '0px 1px 1px rgba(0, 0, 0, 0.15)' }}>
-      ?
-    </Badge.Notification>
+    <HoverNotification copy={hoverText}>
+      <Badge.Notification style={{ margin: '0 10px', cursor: 'pointer', background: '#7C80F2', boxShadow: '0px 1px 1px rgba(0, 0, 0, 0.15)' }}>
+        ?
+      </Badge.Notification>
+    </HoverNotification>
   </Text>
 )
 
@@ -131,6 +140,14 @@ const monthlyAllowanceStyle = `
   .item + .item {
     margin-top: 1rem;
   }
+
+  @media only screen and (max-width: 1152px) {
+    width: 50%;
+  }
+
+  @media only screen and (max-width: 600px) {
+    width: 100%;
+  }
 `
 
 const ContentWrapper = styled.div`
@@ -163,6 +180,34 @@ const ContentWrapper = styled.div`
       display: flex;
       flex-direction: column;
       width: 50%;
+    }
+  }
+
+  @media only screen and (max-width: 1152px) {
+    .settings {
+      width: 50%;
+    }
+    .settings-content {
+      flex-direction: column;
+      > div {
+        width: 100%;
+      }
+      > div:first-child {
+        margin-bottom: 2rem;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 768px) {
+    padding: 1rem;
+  }
+
+  @media only screen and (max-width: 600px) {
+    flex-direction: column;
+
+    .settings {
+      width: 100%;
+      margin-bottom: 1rem;
     }
   }
 `


### PR DESCRIPTION
Closes #36 

Looking for feedback to generalize this a bit further before requesting A1 to consider adding it to `aragon-ui`

Some possible improvements:
- [ ] Use `React.forwardRef` for the HOC, for our particular use case this was not needed but an argument could be made for other types of hover states would like to have access to the `ref` of the component to be wrapped.
- [ ] Change the API to not render its `children` but instead pass the component to trigger the hover state as a prop.