### PR TITLE
Fix audit issue 6.11

### DIFF
--- a/apps/kit-aragon-fundraising/README.md
+++ b/apps/kit-aragon-fundraising/README.md
@@ -26,7 +26,7 @@ The fundraising kit relies on two category of actors: the project managers and t
 | Token Manager (BON) | BURN                        | MarketMaker         | Voting (BON) |
 | Voting (BON)        | CREATE_VOTES                | Token Manager (BON) | Voting (BON) |
 | Voting (BON)        | MODIFY_QUORUM               | Voting (BON)        | Voting (BON) |
-| Tap                 | UPDATE_BENEFICIARY          | Voting (PRO)        | Voting (PRO) |
+| Tap                 | UPDATE_BENEFICIARY          | Controller          | Voting (BON) |
 | Tap                 | UPDATE_MONTHLY_TAP_INCREASE | Controller          | Voting (BON) |
 | Tap                 | ADD_TOKEN_TAP               | Controller          | Voting (BON) |
 | Tap                 | UPDATE_TOKEN_TAP            | Controller          | Voting (BON) |
@@ -34,11 +34,13 @@ The fundraising kit relies on two category of actors: the project managers and t
 | Pool                | SAFE_EXECUTE                | Voting (BON)        | Voting (BON) |
 | Pool                | ADD_COLLATERAL_TOKEN        | Controller          | Voting (BON) |
 | Pool                | TRANSFER                    | Tap, Controller     | Voting (BON) |
+| MarketMaker         | UPDATE_BENEFICIARY          | Controller          | Voting (BON) |
 | MarketMaket         | ADD_COLLATERAL_TOKEN        | Controller          | Voting (BON) |
 | MarketMaket         | UPDATE_COLLATERAL_TOKEN     | Controller          | Voting (BON) |
 | MarketMaket         | UPDATE_FEE                  | Controller          | Voting (BON) |
 | MarketMaket         | CREATE_BUY_ORDER            | Controller          | Voting (BON) |
 | MarketMaket         | CREATE_SELL_ORDER           | Controller          | Voting (BON) |
+| Controller          | UPDATE_BENEFICIARY          | Voting (PRO)        | Voting (BON) |
 | Controller          | ADD_COLLATERAL_TOKEN        | Voting (BON)        | Voting (BON) |
 | Controller          | UPDATE_TOKEN_TAP            | Voting (BON)        | Voting (BON) |
 | Controller          | UPDATE_MONTHLY_TAP_INCREASE | Voting (BON)        | Voting (BON) |

--- a/apps/kit-aragon-fundraising/contracts/FundraisingKit.sol
+++ b/apps/kit-aragon-fundraising/contracts/FundraisingKit.sol
@@ -202,13 +202,14 @@ contract FundraisingKit is APMNamehash, IsContract, KitBase {
         acl.createBurnedPermission(voting, voting.MODIFY_SUPPORT_ROLE());
 
         // Tap
-        acl.createPermission(multisig, tap, tap.UPDATE_BENEFICIARY_ROLE(), multisig);
+        acl.createPermission(controller, tap, tap.UPDATE_BENEFICIARY_ROLE(), voting);
         acl.createPermission(controller, tap, tap.UPDATE_MONTHLY_TAP_INCREASE_ROLE(), voting);
         acl.createPermission(controller, tap, tap.ADD_TOKEN_TAP_ROLE(), voting);
         acl.createPermission(controller, tap, tap.UPDATE_TOKEN_TAP_ROLE(), voting);
         acl.createPermission(controller, tap, tap.WITHDRAW_ROLE(), multisig);
 
         // BancorMarketMaker
+        acl.createPermission(controller, marketMaker, marketMaker.UPDATE_BENEFICIARY_ROLE(), voting);
         acl.createPermission(controller, marketMaker, marketMaker.ADD_COLLATERAL_TOKEN_ROLE(), voting);
         acl.createPermission(controller, marketMaker, marketMaker.UPDATE_COLLATERAL_TOKEN_ROLE(), voting);
         acl.createPermission(controller, marketMaker, marketMaker.UPDATE_FEES_ROLE(), voting);
@@ -224,6 +225,7 @@ contract FundraisingKit is APMNamehash, IsContract, KitBase {
 
         // Controller
         acl.createPermission(this, controller, controller.ADD_COLLATERAL_TOKEN_ROLE(), this);
+        acl.createPermission(multisig, controller, controller.UPDATE_BENEFICIARY_ROLE(), voting);
         acl.createPermission(voting, controller, controller.UPDATE_TOKEN_TAP_ROLE(), voting);
         acl.createPermission(voting, controller, controller.UPDATE_MONTHLY_TAP_INCREASE_ROLE(), voting);
         acl.createPermission(address(-1), controller, controller.CREATE_BUY_ORDER_ROLE(), voting);

--- a/apps/kit-aragon-fundraising/test/fundraising.js
+++ b/apps/kit-aragon-fundraising/test/fundraising.js
@@ -262,13 +262,14 @@ contract('FundraisingKit', accounts => {
         await checkRole(poolAddress, await pool.TRANSFER_ROLE(), votingAddress, 'Pool', 'TRANSFER_ROLE', marketMakerAddress)
 
         // tap
-        await checkRole(tapAddress, await tap.UPDATE_BENEFICIARY_ROLE(), multisigAddress, 'Tap', 'UPDATE_BENEFICIARY_ROLE')
+        await checkRole(tapAddress, await tap.UPDATE_BENEFICIARY_ROLE(), votingAddress, 'Tap', 'UPDATE_BENEFICIARY_ROLE', controllerAddress)
         await checkRole(tapAddress, await tap.UPDATE_MONTHLY_TAP_INCREASE_ROLE(), votingAddress, 'Tap', 'UPDATE_MONTHLY_TAP_INCREASE_ROLE', controllerAddress)
         await checkRole(tapAddress, await tap.ADD_TOKEN_TAP_ROLE(), votingAddress, 'Tap', 'ADD_TOKEN_TAP_ROLE', controllerAddress)
         await checkRole(tapAddress, await tap.UPDATE_TOKEN_TAP_ROLE(), votingAddress, 'Tap', 'UPDATE_TOKEN_TAP_ROLE', controllerAddress)
         await checkRole(tapAddress, await tap.WITHDRAW_ROLE(), multisigAddress, 'Tap', 'WITHDRAW_ROLE', controllerAddress)
 
         // controller
+        await checkRole(controllerAddress, await controller.UPDATE_BENEFICIARY_ROLE(), votingAddress, 'Controller', 'UPDATE_BENEFICIARY_ROLE', multisigAddress)
         await checkRole(controllerAddress, await controller.ADD_COLLATERAL_TOKEN_ROLE(), votingAddress, 'Controller', 'ADD_COLLATERAL_TOKEN_ROLE')
         await checkRole(controllerAddress, await controller.UPDATE_TOKEN_TAP_ROLE(), votingAddress, 'Controller', 'UPDATE_TOKEN_TAP_ROLE')
         await checkRole(controllerAddress, await controller.UPDATE_MONTHLY_TAP_INCREASE_ROLE(), votingAddress, 'Controller', 'UPDATE_MONTHLY_TAP_INCREASE_ROLE')
@@ -293,6 +294,15 @@ contract('FundraisingKit', accounts => {
           'UPDATE_COLLATERAL_TOKEN_ROLE',
           controllerAddress
         )
+        await checkRole(
+          controllerAddress,
+          await marketMaker.UPDATE_BENEFICIARY_ROLE(),
+          votingAddress,
+          'MarketMaker',
+          'UPDATE_BENEFICIARY_ROLE',
+          multisigAddress
+        )
+
         await checkRole(marketMakerAddress, await marketMaker.UPDATE_FEES_ROLE(), votingAddress, 'Controller', 'UPDATE_FEES_ROLE', controllerAddress)
 
         await checkRole(marketMakerAddress, await marketMaker.CREATE_BUY_ORDER_ROLE(), votingAddress, 'Controller', 'CREATE_BUY_ORDER_ROLE', controllerAddress)


### PR DESCRIPTION
The original comments for this issue were:
> According to the Permission Table `Voting (PRO)` directly interacts with `Tap` instead of changing the beneficiary via the defined interfaces of `Controller` (or the method is redundant) and `UPDATE_BENEFICIARY` on `Controller` is not assigned to an external actor. The controller's functionality to update the beneficiary both in `Tap` and `MarketMaker` can therefore not be used with the permission-set outlined in the Kit's Readme.

> In addition to that `Voting (BON)` is bypassing the `Controller` to directly call `SAFE_EXECUTE` on the `Pool`. This appears to be inconsistent with an architecture where external actors are only to interact with the interface contract `Controller` as the entry point to the "fundraising" application.

This PR fixes the first issue [which actually looks cleaner than the way we set the permissions before]. Though the second point is not really an issue as the `safeExecute` function is not supposed to be called from the `Controller` contract but mostly through some external UI such as the one Frame is working on: https://www.youtube.com/watch?v=24KaOcK38DQ