### PR TITLE
Improved sorting and added data export

### DIFF
--- a/apps/aragon-fundraising/app/src/screens/Orders.js
+++ b/apps/aragon-fundraising/app/src/screens/Orders.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState, useCallback } from 'react'
 import {
   Button,
   ContextMenu,
@@ -13,9 +13,14 @@ import {
   theme,
   unselectable,
   useLayout,
+  ButtonBase,
+  IconDown,
+  IconUp,
+  IconExternal,
 } from '@aragon/ui'
 import { useApi, useAppState, useConnectedAccount } from '@aragon/api-react'
 import { format, subYears, endOfToday } from 'date-fns'
+import { saveAs } from 'file-saver'
 import styled from 'styled-components'
 import ToggleFiltersButton from '../components/ToggleFiltersButton'
 import OrderTypeTag from '../components/Orders/OrderTypeTag'
@@ -46,6 +51,26 @@ const withMatchingFilter = (order, { active, payload, type }) => {
   if (payload[active] === 'All') return true
   // the filter should only keep the matching orders
   else return payload[active].toLowerCase() === order[type].toLowerCase()
+}
+
+const SortHeader = ({ onClick, label, sortBy = 0, rightAligned = false }) => {
+  return (
+    <ButtonBase
+      onClick={onClick}
+      css={`
+        display: inline-flex;
+        align-items: center;
+        flex-direction: ${rightAligned ? 'row-reverse' : 'row'};
+      `}
+    >
+      <span css="margin-top: 2px; font-size: 12px; font-weight: 600;">{label}</span>
+
+      <span css="width: 5px" />
+
+      {sortBy === 1 && <IconDown size="tiny" />}
+      {sortBy === -1 && <IconUp size="tiny" />}
+    </ButtonBase>
+  )
 }
 
 export default ({ myOrders }) => {
@@ -82,16 +107,58 @@ export default ({ myOrders }) => {
   const symbols = ['All'].concat(Array.from(new Set(filteredOrders.map(o => o.symbol))))
   const users = ['All'].concat(Array.from(new Set(filteredOrders.map(o => o.user))))
   const [typeFilter, setTypeFilter] = useState({ active: 0, payload: ['All', 'Buy', 'Sell'], type: 'type' })
-  const [priceFilter, setPriceFilter] = useState({ active: 0, payload: ['Default', 'Ascending', 'Descending'], type: 'price' })
   const [symbolFilter, setSymbolFilter] = useState({ active: 0, payload: symbols, type: 'symbol' })
   const [userFilter, setUserFilter] = useState({ active: 0, payload: users, type: 'user' })
   const [dateFilter, setDateFilter] = useState({ payload: { start: subYears(new Date(), 1).getTime(), end: endOfToday().getTime() }, type: 'date' })
   const [showFilters, setShowFilters] = useState(false)
   const [page, setPage] = useState(0)
   const { name: layoutName } = useLayout()
+
+  const [sortBy, setSortBy] = useState(['', 0])
+
+  // rotates as such: 0 -> 1 -> -1 -> 0 and so on...
+  // 0 is the default state
+  // 1 is the ascending state
+  // -1 is the descending state
+  const rotateSortBy = useCallback(name => {
+    setSortBy(sortBy => [name, sortBy[0] === name ? ((sortBy[1] + 2) % 3) - 1 : 1])
+  }, [])
+
+  const rotateSortByPrice = useCallback(() => {
+    rotateSortBy('price')
+  }, [rotateSortBy])
+
+  const rotateSortByTokens = useCallback(() => {
+    rotateSortBy('tokens')
+  }, [rotateSortBy])
+
+  const rotateSortByAmount = useCallback(() => {
+    rotateSortBy('amount')
+  }, [rotateSortBy])
+
+  const rotateSortByDate = useCallback(() => {
+    rotateSortBy('date')
+  }, [rotateSortBy])
+
   const dataViewFields = myOrders
-    ? ['Date', 'Status', 'Order Amount', 'Token Price', 'Order Type', 'Tokens', 'Actions']
-    : ['Date', 'Holder', 'Status', 'Order Amount', 'Token Price', 'Order Type', 'Tokens']
+    ? [
+        <SortHeader label="Date" onClick={rotateSortByDate} sortBy={sortBy[0] === 'date' && sortBy[1]} />,
+        'Status',
+        <SortHeader label="Order Amount" onClick={rotateSortByAmount} sortBy={sortBy[0] === 'amount' && sortBy[1]} />,
+        <SortHeader label="Token Price" onClick={rotateSortByPrice} sortBy={sortBy[0] === 'price' && sortBy[1]} />,
+        'Order Type',
+        <SortHeader label="Tokens" onClick={rotateSortByTokens} sortBy={sortBy[0] === 'tokens' && sortBy[1]} />,
+        'Actions',
+      ]
+    : [
+        <SortHeader label="Date" onClick={rotateSortByDate} sortBy={sortBy[0] === 'date' && sortBy[1]} />,
+        'Holder',
+        'Status',
+        <SortHeader label="Order Amount" onClick={rotateSortByAmount} sortBy={sortBy[0] === 'amount' && sortBy[1]} />,
+        <SortHeader label="Token Price" onClick={rotateSortByPrice} sortBy={sortBy[0] === 'price' && sortBy[1]} />,
+        'Order Type',
+        <SortHeader label="Tokens" onClick={rotateSortByTokens} sortBy={sortBy[0] === 'tokens' && sortBy[1]} />,
+      ]
 
   // *****************************
   // effects
@@ -129,15 +196,28 @@ export default ({ myOrders }) => {
       .filter(o => withMatchingFilter(o, typeFilter))
       // reverse the result
       .reverse()
-      // sort by price
+      // sort by price, tokens, amount or date
       .sort((a, b) => {
-        const pricePayload = priceFilter.payload[priceFilter.active]
-        if (pricePayload === 'Ascending') return a.price.minus(b.price).toNumber()
-        else if (pricePayload === 'Descending') return b.price.minus(a.price).toNumber()
-        else return 0
+        if (sortBy[0] === 'price') {
+          if (sortBy[1] === -1) return a.price.minus(b.price).toNumber()
+          else if (sortBy[1] === 1) return b.price.minus(a.price).toNumber()
+          else return 0
+        } else if (sortBy[0] === 'tokens') {
+          if (sortBy[1] === -1) return a.amount.minus(b.amount).toNumber()
+          else if (sortBy[1] === 1) return b.amount.minus(a.amount).toNumber()
+          else return 0
+        } else if (sortBy[0] === 'amount') {
+          if (sortBy[1] === -1) return a.value.minus(b.value).toNumber()
+          else if (sortBy[1] === 1) return b.value.minus(a.value).toNumber()
+          else return 0
+        } else if (sortBy[0] === 'date') {
+          if (sortBy[1] === -1) return a.timestamp - b.timestamp
+          else if (sortBy[1] === 1) return b.timestamp - a.timestamp
+          else return 0
+        }
       })
     setFilteredOrders(filteredOrders)
-  }, [updatedOrders, typeFilter, priceFilter, symbolFilter, userFilter, dateFilter])
+  }, [updatedOrders, typeFilter, symbolFilter, userFilter, dateFilter, sortBy])
 
   // *****************************
   // handlers
@@ -150,6 +230,19 @@ export default ({ myOrders }) => {
         .toPromise()
         .catch(console.error)
     }
+  }
+
+  const handleDownload = () => {
+    const mappedData = filteredOrders.map(order => {
+      return `${format(order.timestamp, 'MM/dd/yyyy - HH:mm:ss')},${order.user},${order.state},${formatBigNumber(
+        order.value,
+        order.symbol === 'DAI' ? daiDecimals : antDecimals
+      ) + ` ${order.symbol}`},${'$' + formatBigNumber(order.price, 0)},${order.type},${formatBigNumber(order.amount, tokenDecimals)}`
+    })
+    const result = ['Date,Holder,Status,Order Amount,Token Price,Order Type,Tokens'].concat(mappedData).join('\n')
+    const today = format(Date.now(), 'yyyy-MM-dd')
+    const filename = `fundraising_${today}.csv`
+    saveAs(new Blob([result], { type: 'text/csv;charset=utf-8' }), filename)
   }
 
   return (
@@ -181,6 +274,7 @@ export default ({ myOrders }) => {
                       selected={userFilter.active}
                       renderLabel={() => shortenAddress(userFilter.payload[userFilter.active])}
                       onChange={idx => setUserFilter({ ...userFilter, active: idx })}
+                      css="min-width: auto;"
                     />
                   </div>
                 )}
@@ -193,8 +287,9 @@ export default ({ myOrders }) => {
                   <DropDown items={typeFilter.payload} selected={typeFilter.active} onChange={idx => setTypeFilter({ ...typeFilter, active: idx })} />
                 </div>
                 <div className="filter-item">
-                  <span className="filter-label">Price</span>
-                  <DropDown items={priceFilter.payload} selected={priceFilter.active} onChange={idx => setPriceFilter({ ...priceFilter, active: idx })} />
+                  <Button onClick={handleDownload}>
+                    <IconExternal /> Export
+                  </Button>
                 </div>
               </div>
             </div>
@@ -267,7 +362,6 @@ const ContentWrapper = styled.div`
   .filter-nav {
     display: flex;
     justify-content: flex-end;
-    margin-right: 1.5rem;
     margin-top: 1rem;
     margin-bottom: 1rem;
   }


### PR DESCRIPTION
Fixes issue #68. You can now sort if you click on the table label.
- `DATE`, `ORDER AMOUNT`, `PRICE` and `TOKENS`.

It exports a CSV file.
# Preview
![DataView](https://i.gyazo.com/52747285c95b2c5bb8439fd0b0e6fcdb.png)
