### PR TITLE
Fundraising UI tweaks

### DIFF
--- a/apps/aragon-fundraising/app/src/components/CircleGraph.js
+++ b/apps/aragon-fundraising/app/src/components/CircleGraph.js
@@ -40,6 +40,7 @@ const CircleGraph = ({ value, label, size, color, width }) => {
               cy={size / 2}
               r={radius}
               color={color}
+              strokeLinecap="round"
               style={{
                 strokeDasharray: length,
                 strokeDashoffset: progressValue.interpolate(t => length - (length * t) / 2),

--- a/apps/aragon-fundraising/app/src/components/NewContribution/Contribution.js
+++ b/apps/aragon-fundraising/app/src/components/NewContribution/Contribution.js
@@ -48,9 +48,10 @@ export default () => {
       setValue('')
       setValid(false)
       setErrorMessage(null)
-      // focus the right input, given the order type
-      // timeout to avoid some flicker
-      valueInput && setTimeout(() => valueInput.current.focus(), 20)
+
+      // Focus the right input after some time to avoid the panel transition to
+      // be skipped by the browser.
+      valueInput && setTimeout(() => valueInput.current.focus(), 100)
     }
   }, [presalePanel])
 

--- a/apps/aragon-fundraising/app/src/components/Orders/OrderState.js
+++ b/apps/aragon-fundraising/app/src/components/Orders/OrderState.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { IconCheck, IconEllipsis, GU } from '@aragon/ui'
 import { Order } from '../../constants'
-import overIcon from '../../assets/overIcon.svg'
+import overIcon from '../../assets/OverIcon.svg'
 
 export default ({ state }) => {
   let icon

--- a/apps/aragon-fundraising/app/src/components/PresaleGoal.js
+++ b/apps/aragon-fundraising/app/src/components/PresaleGoal.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import { useAppState, useApi, useConnectedAccount } from '@aragon/api-react'
-import { Box, Button, GU } from '@aragon/ui'
+import { Box, Button, useTheme, GU, textStyle } from '@aragon/ui'
 import CircleGraph from '../components/CircleGraph'
 import { PresaleViewContext } from '../context'
 import { Presale } from '../constants'
@@ -54,17 +54,50 @@ export default () => {
     }
   }
 
+  const theme = useTheme()
+
   return (
     <Box heading="Presale Goal">
       <div className="circle">
-        <CircleGraph value={totalRaised.div(goal).toNumber()} size={224} width={6} color={circleColor[state]} />
-        <div>
-          <p css="color: #212B36; display: inline;">{formatBigNumber(totalRaised, decimals)}</p> {symbol} of{' '}
-          <p css="color: #212B36; display: inline;">{formatBigNumber(goal, decimals)}</p> {symbol}
-        </div>
+        <CircleGraph value={totalRaised.div(goal).toNumber()} size={20.5 * GU} width={6} color={circleColor[state]} />
+        <p
+          title={`${formatBigNumber(totalRaised, decimals)} ${symbol} of ${formatBigNumber(goal, decimals)} ${symbol}`}
+          css={`
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: ${theme.surfaceContentSecondary};
+          `}
+        >
+          <span
+            css={`
+              color: ${theme.surfaceContent};
+            `}
+          >
+            {formatBigNumber(totalRaised, decimals)}
+          </span>{' '}
+          {symbol} of{' '}
+          <span
+            css={`
+              color: ${theme.surfaceContent};
+            `}
+          >
+            {formatBigNumber(goal, decimals)}
+          </span>{' '}
+          {symbol}
+        </p>
         {state === Presale.state.GOAL_REACHED && (
           <>
-            <p>Presale goal completed!</p>
+            <p
+              css={`
+                white-space: nowrap;
+                margin-top: ${2 * GU}px;
+                color: ${theme.surfaceContent};
+              `}
+            >
+              <strong>Presale goal completed! 🎉</strong>
+            </p>
             <Button
               wide
               mode="strong"
@@ -81,7 +114,13 @@ export default () => {
         )}
         {state === Presale.state.REFUNDING && (
           <>
-            <p css="color: #212B36; font-weight: 300; font-size: 16px;">Unfortunately, the goal set for this presale has not been reached.</p>
+            <p
+              css={`
+                margin-top: ${2 * GU}px;
+              `}
+            >
+              Unfortunately, the goal set for this presale has not been reached.
+            </p>
             <Button
               wide
               mode="strong"


### PR DESCRIPTION
- CircleGraph: use rounded ends.
- Fix the SidePanel transition jump (seems to have been reverted at some point).
- Fix import case.
- Presale goal fixes:
  - Use colors from the theme.
  - Use text styles.
  - Tweak the spacing / sizing of elements.
  - Ensure it doesn’t break with large amounts.
  - Add the 🎉 emoji on success.

