### PR TITLE
Change dev server port to 3006

### DIFF
--- a/apps/aragon-fundraising/app/package.json
+++ b/apps/aragon-fundraising/app/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "eslint ./src",
     "sync-assets": "copy-aragon-ui-assets -n aragon-ui ./build && copyfiles -u 1 './public/**/*' ./build",
-    "start": "npm run sync-assets && npm run build:script -- --no-minify && parcel serve index.html -p 3001 --out-dir build/",
+    "start": "npm run sync-assets && npm run build:script -- --no-minify && parcel serve index.html -p 3006 --out-dir build/",
     "build": "npm run sync-assets && npm run build:script:nosourcemap && parcel build index.html --out-dir build/ --public-url '.' --no-source-maps",
     "build:script": "parcel build src/script.js --out-dir build/",
     "build:script:nosourcemap": "cross-env NODE_ENV=production parcel build src/script.js --out-dir build/ --no-source-maps"


### PR DESCRIPTION
Not sure if changing this is safe or if it has any impact (is there any tool relying on it to be 3001?).

The 3001 port is also used by the Voting app dev server, so this avoids conflicts between the two. I started assigning 3006 to the Fundraising app [in this PR](https://github.com/aragon/aragon/pull/1124), which also adds the possibility to use local apps individually (removing the need to edit the `environment.js` file in aragon/aragon).