### PR TITLE
Mainnet improvements (see #154)

### DIFF
--- a/apps/aragon-fundraising/app/src/script.js
+++ b/apps/aragon-fundraising/app/src/script.js
@@ -337,6 +337,7 @@ const handleCollateralToken = async (state, { collateral, reserveRatio, slippage
     loadCollateralsToBeClaimed(collateral, settings),
   ])
   collaterals.set(collateral, {
+    ...collaterals.get(collateral),
     symbol,
     name,
     decimals: parseInt(decimals, 10),


### PR DESCRIPTION
Trying to fix race condition on collaterals/taps:
- Don't overwrite tap values if the `AddCollateralToken` is arriving after `AddTappedToken`